### PR TITLE
fix folder name in version dev-master

### DIFF
--- a/src/PW/Composer/Installer.php
+++ b/src/PW/Composer/Installer.php
@@ -58,7 +58,8 @@ class Installer extends LibraryInstaller
 	{
 		$installPath = $this->getInstallPath($package);
 		$downloadPath = $this->getDownloadPath($package);
-		$processwireDownloadPath = $downloadPath . "/processwire-{$package->getPrettyVersion()}";
+		$version = str_replace('dev-', '', $package->getPrettyVersion());
+		$processwireDownloadPath = $downloadPath . "/processwire-{$version}";
 
 		$this->downloadProcesswire($package, $downloadPath);
 


### PR DESCRIPTION
If you use "dev-master" as the version, the script will look for the "processwire-dev-master" folder. The unzipped folder name is "processwire-master".